### PR TITLE
fix: Segment connected hatch paths at large gaps for improved renderi…

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "three-plotter-renderer",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "An SVG renderer for Three.js with hidden line removal - designed for pen plotters and laser cutters",
   "type": "module",
   "main": "dist/three-plotter-renderer.umd.js",


### PR DESCRIPTION
### **User description**
…ng and update package version.


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Segment connected hatch paths at large gaps to prevent visual artifacts

- Calculate maximum connection distance based on hatch spacing

- Break paths when gap exceeds threshold, creating multiple path elements

- Update package version to 1.1.1


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Hatch paths"] --> B["Calculate max connection distance"]
  B --> C["Iterate through hatches"]
  C --> D{"Distance > threshold?"}
  D -->|Yes| E["Start new path"]
  D -->|No| F["Connect to previous"]
  E --> G["Create path elements"]
  F --> G
  G --> H["Render SVG paths"]
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>plotter-renderer.js</strong><dd><code>Implement gap-based hatch path segmentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/plotter-renderer.js

<ul><li>Refactored hatch connection logic to break paths at large gaps<br> <li> Calculate <code>maxConnectDist</code> threshold using base spacing and scale<br> <li> Track <code>prevEnd</code> position and check distance before connecting hatches<br> <li> Create multiple path elements instead of single continuous path<br> <li> Preserve boustrophedon alternation for pen travel optimization</ul>


</details>


  </td>
  <td><a href="https://github.com/neurofuzzy/three-plotter-renderer/pull/14/files#diff-c3fe0dad7fb20fb0166952cd45062e2c60ffeeced8c56a2ae0c7bbf539d3c950">+43/-12</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>package.json</strong><dd><code>Update package version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

package.json

- Bump version from 1.1.0 to 1.1.1


</details>


  </td>
  <td><a href="https://github.com/neurofuzzy/three-plotter-renderer/pull/14/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

